### PR TITLE
docs: polish packaging, docs config, and CI actions

### DIFF
--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -7,7 +7,7 @@ jobs:
     name: Paper Draft
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Build draft PDF
         uses: openjournals/openjournals-draft-action@master
         with:
@@ -15,7 +15,7 @@ jobs:
           # This should be the path to the paper within your repo.
           paper-path: JOSS/paper.md
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: paper
           # This is also the output path where Pandoc will write the compiled

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.x"
 
@@ -29,7 +29,7 @@ jobs:
         run: python -m pip install --upgrade twine && twine check dist/*
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-package-distributions
           path: dist/
@@ -48,10 +48,37 @@ jobs:
 
     steps:
       - name: Download distributions
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: python-package-distributions
           path: dist/
 
       - name: Publish distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  docs:
+    name: Activate and build Read the Docs
+    needs: publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Activate tagged version on Read the Docs
+        env:
+          RTD_TOKEN: ${{ secrets.RTD_API_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          curl -sS -X PATCH \
+            -H "Authorization: Token ${RTD_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d '{"active": true, "hidden": false}' \
+            "https://readthedocs.org/api/v3/projects/wavespace/versions/${TAG}/"
+
+      - name: Trigger Read the Docs build
+        env:
+          RTD_TOKEN: ${{ secrets.RTD_API_TOKEN }}
+        run: |
+          curl -sS -X POST \
+            -H "Authorization: Token ${RTD_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d '{"commit_sha": "${{ github.sha }}"}' \
+            "https://readthedocs.org/api/v3/projects/wavespace/builds/"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv and set up Python ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v10.0.0
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,10 +17,10 @@ jobs:
     continue-on-error: ${{ matrix.python-version == '3.14' }} # Ignores warning in emd site package 
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv and set up Python ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v10
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv and set up Python ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v10
+        uses: astral-sh/setup-uv@v9
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,8 +17,11 @@ sphinx:
 # Optionally, but recommended,
 # declare the Python requirements required to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#    install:
-#    - requirements: docs/requirements.txt
+python:
+   install:
+     - method: pip
+       path: .
+       extra_requirements:
+         - docs
         
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to WaveSpace are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.1.8] - 2026-08-12
+
+### Added
+- Initial release published on PyPI.
+- `WaveData` container class for multi-channel neural recordings.
+- Simulation, preprocessing, decomposition, spatial arrangement, wave analysis, plotting helpers, statistics, and utils modules.
+- Sphinx documentation hosted on Read the Docs.
+- GitHub Actions workflows for tests (Python 3.9-3.14) and PyPI release on tag.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,10 @@ For questions, bug reports, or feature requests, please open an [issue on GitHub
 * Add or update documentation as needed.
 * Add or update tests when changing or adding functionality.
 
+### Code Style
+
+WaveSpace does not currently enforce a formatter or linter. Please follow the style of the surrounding code: keep functions focused, prefer descriptive names, and avoid unrelated formatting changes mixed into the same pull request.
+
 ### Testing
 
 Please ensure that the test suite passes before submitting a pull request.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,31 @@
 # WaveSpace
-WaveSpace is a Python toolbox for simulating, detecting, and analyzing spatiotemporal traveling waves in neural sensor array data. It provides  tools for generating synthetic datasets, and applying a range of wave analysis techniques such as optical flow, 2D FFT, circular-linear correlation and singular value decomposition. In addition, it contains pipelines to decompose multi-dimensional timeseries data into its frequency components to derive robust phase estimates. WaveSpace’s WaveData class provides a structured approach to managing complex datasets, while its plotting helpers facilitate intuitive visualization of spatiotemporal patterns.
+
+![PyPI version](https://img.shields.io/pypi/v/wavespace)
+![Python versions](https://img.shields.io/pypi/pyversions/wavespace)
+![License](https://img.shields.io/pypi/l/wavespace)
+![Documentation](https://img.shields.io/readthedocs/wavespace)
+![Tests](https://img.shields.io/github/actions/workflow/status/kpetras/WaveSpace/tests.yml?branch=main)
+
+WaveSpace is a Python toolbox for simulating, detecting, and analyzing spatiotemporal traveling waves in neural sensor array data. It provides tools for generating synthetic datasets, and applying a range of wave analysis techniques such as optical flow, 2D FFT, circular-linear correlation and singular value decomposition. In addition, it contains pipelines to decompose multi-dimensional timeseries data into its frequency components to derive robust phase estimates. WaveSpace’s WaveData class provides a structured approach to managing complex datasets, while its plotting helpers facilitate intuitive visualization of spatiotemporal patterns.
 
 ## Documentation
 Access latest documentation from [here](https://wavespace.readthedocs.io/en/latest/)
 
 ## Installation
 
-Download latest version from [here](https://github.com/kpetras/WaveSpace/tree/main/package/dist)
+Install from PyPI with
 
-Open a terminal, navigate to the directory you downloaded to and install with
-```
+```bash
 pip install wavespace
 ```
 
 ## Testing
-   * Run tests locally using Python's built-in `unittest` framework from the `UnitTest` folder:
 
-     ```bash
-     python -m unittest discover UnitTest
+Run tests locally using Python's built-in `unittest` framework from the `UnitTest` folder:
+
+```bash
+python -m unittest discover -s UnitTest -p "*_test.py"
+```
 
 ## Contributing
 See https://github.com/kpetras/WaveSpace/blob/main/CONTRIBUTING.md
@@ -43,11 +51,11 @@ Offers methods for computing null distributions.
 
 ### Utils:
 A collection of general-purpose helper functions used throughout the toolbox, including data manipulation and file I/O.
-#### The `WaveData` Class
+### The `WaveData` Class
 
 The `WaveData` class serves as a container for time-series data related to cortical traveling waves. It provides functionalities for data storage, manipulation, and analysis, ensuring a structured workflow for handling multi-channel neural recordings. 
 
-##### **Key Features**
+#### **Key Features**
 - **Initialization (`__init__`)**: Stores channel positions, time vectors, sample rates, and maintains a structured dataset with multiple *DataBuckets* for flexible data handling.
 - **Data Management**:
   - Supports multiple datasets through *DataBuckets*, enabling users to store, retrieve, and manipulate data flexibly.
@@ -64,9 +72,9 @@ The `WaveData` class serves as a container for time-series data related to corti
   - Saves objects to files for later retrieval (`save_to_file`).
   - Provides a structured string representation (`__repr__`) for quick dataset summaries.
 
-This class is essential for organizing and processing large-scale neural recordings, offering flexibility in data structuring, preprocessing, and visualization. Let me know if you’d like any refinements!
+This class is essential for organizing and processing large-scale neural recordings, offering flexibility in data structuring, preprocessing, and visualization. 
 
-### Wave Analysis: 
+### Wave Analysis
 Core module for detecting, characterizing, and quantifying cortical traveling waves using advanced signal processing techniques.
 
 ![overview](JOSS/WaveSpace_overview_smaller.png)

--- a/WaveSpace/PlottingHelpers/Plotting.py
+++ b/WaveSpace/PlottingHelpers/Plotting.py
@@ -423,7 +423,7 @@ def animate_grid_data(gridData,DataBucketName = "", dataInd = None, probepositio
                     origin='lower', vmin=vmin, vmax=vmax, cmap="copper")
 
     cbar = plt.colorbar(img)
-    cbar.set_label('$\mu$V')
+    cbar.set_label(r'$\mu$V')
     nFrames = dataToPlot.shape[-1]  
     lengthOfMatrix =  dataToPlot.shape[0] * dataToPlot.shape[1]
     # make all black
@@ -674,7 +674,7 @@ def plot_optical_flow(waveData, PlottingDataBucketName = None, UVBucketName = No
         ax2.set_xticklabels(radian_labels)
     else:
         cbar = plt.colorbar(img)
-        cbar.set_label('$\mu$V')
+        cbar.set_label(r'$\mu$V')
 
     ani = animation.FuncAnimation(plt.gcf(),
                                 AnimateFullStatus, fargs=(plotData, timevec),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,27 +7,40 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 import os
 import sys
+from importlib.metadata import version as _pkg_version
 
 sys.path.insert(0, os.path.abspath(".."))
 
-project = 'WaveSpace'
-copyright = '2025, Kirsten Petras, Dennis Croonenberg, Laura Dugué'
-author = 'Kirsten Petras, Dennis Croonenberg, Laura Dugué'
-release = '1.1.8'
+project = "WaveSpace"
+copyright = "2025–2026, Kirsten Petras, Dennis Croonenberg, Laura Dugué"
+author = "Kirsten Petras, Dennis Croonenberg, Laura Dugué"
+release = _pkg_version("WaveSpace")
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.autosummary"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.viewcode",
+]
+
+intersphinx_mapping = {
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
+    "matplotlib": ("https://matplotlib.org/stable/", None),
+    "pandas": ("https://pandas.pydata.org/docs/", None),
+    "mne": ("https://mne.tools/stable/", None),
+}
 
 autosummary_generate = True
-templates_path = ['_templates']
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
-
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'alabaster'
-
+html_theme = "pydata_sphinx_theme"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -76,7 +76,7 @@ To contribute to WaveSpace or work with the source code, clone the repository an
 
 The development environment includes the tools required to run the test suite and test WaveSpace across its supported Python versions.
 
-For more information about contributing and testing, see the [Contributing guide](https://github.com/kpetras/WaveSpace/blob/main/CONTRIBUTING.md).
+For more information about contributing and testing, see the `Contributing guide <https://github.com/kpetras/WaveSpace/blob/main/CONTRIBUTING.md>`_.
 
 Examples
 --------
@@ -85,14 +85,14 @@ WaveSpace includes a set of tutorials demonstrating common workflows for simulat
 
 The tutorials include:
 
-* [Creating a WaveData Object](https://wavespace.readthedocs.io/en/latest/source/tutorials/Create_WaveData.html)
-* [Simulating WaveData](https://wavespace.readthedocs.io/en/latest/source/tutorials/Simulate_WaveData.html)
-* [Frequency Decomposition](https://wavespace.readthedocs.io/en/latest/source/tutorials/Frequency_Decomposition.html)
-* [Sensor Layout](https://wavespace.readthedocs.io/en/latest/source/tutorials/Sensor_layout.html)
-* [2D FFT Analysis](https://wavespace.readthedocs.io/en/latest/source/tutorials/2DFFT.html)
-* [Circular-Linear Correlation](https://wavespace.readthedocs.io/en/latest/source/tutorials/CircLinCorr.html)
-* [Wave Basis Functions](https://wavespace.readthedocs.io/en/latest/source/tutorials/Wave_Activity.html)
-* [Optical Flow Analysis](https://wavespace.readthedocs.io/en/latest/source/tutorials/optical_flow.html)
+* `Creating a WaveData Object <https://wavespace.readthedocs.io/en/latest/source/tutorials/Create_WaveData.html>`_
+* `Simulating WaveData <https://wavespace.readthedocs.io/en/latest/source/tutorials/Simulate_WaveData.html>`_
+* `Frequency Decomposition <https://wavespace.readthedocs.io/en/latest/source/tutorials/Frequency_Decomposition.html>`_
+* `Sensor Layout <https://wavespace.readthedocs.io/en/latest/source/tutorials/Sensor_layout.html>`_
+* `2D FFT Analysis <https://wavespace.readthedocs.io/en/latest/source/tutorials/2DFFT.html>`_
+* `Circular-Linear Correlation <https://wavespace.readthedocs.io/en/latest/source/tutorials/CircLinCorr.html>`_
+* `Wave Basis Functions <https://wavespace.readthedocs.io/en/latest/source/tutorials/Wave_Activity.html>`_
+* `Optical Flow Analysis <https://wavespace.readthedocs.io/en/latest/source/tutorials/optical_flow.html>`_
 
 These examples are intended both as introductions to the package and as starting points for applying WaveSpace to real or simulated neural data.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,9 @@ readme = "README.md"
 license = "GPL-3.0-or-later"
 license-files = ["LICENSE"]
 authors = [
-    { name = "Kirsten Petras, Dennis Croonenberg, Laura Dugué" }
+    { name = "Kirsten Petras" },
+    { name = "Dennis Croonenberg" },
+    { name = "Laura Dugué" },
 ]
 requires-python = ">=3.9"
 keywords = [
@@ -32,8 +34,8 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
 ]
-dependencies = [
-    "numpy",
+dependencies = [    
+    "numpy>=2.0.2",
     "matplotlib",
     "scipy",
     "plotly",
@@ -53,12 +55,18 @@ Repository = "https://github.com/kpetras/WaveSpace"
 Issues = "https://github.com/kpetras/WaveSpace/issues"
 Documentation = "https://wavespace.readthedocs.io"
 
+[project.optional-dependencies]
+docs = [
+    "sphinx",
+    "pydata-sphinx-theme",
+]
+
 [dependency-groups]
-test = []
 dev = [
     "tox",
     "tox-uv",
     "sphinx",
+    "pydata-sphinx-theme",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
This is in reference to #29 

- pyproject: split authors, add numpy pin, add docs extra
- README: add badges, replace stale install path, fix broken code fence
- README: remove AI leftover text, flatten heading nesting
- CONTRIBUTING: add Code Style subsection, clarify tox ordering
- docs/conf.py: dynamic release, add napoleon/intersphinx/viewcode
- docs/conf.py: switch to pydata_sphinx_theme
- docs/index.rst: convert markdown links to RST, fix underline
- .readthedocs.yaml: install package + docs extras on RTD
- release.yml: add docs job to activate/build RTD version
- workflows: bump checkout@v7, setup-python@v7, upload-artifact@v7
- workflows: bump download-artifact@v8, setup-uv@v10
- Plotting.py: fix invalid \m escape sequences in matplotlib labels
- CHANGELOG.md: initial Keep-a-Changelog skeleton for 1.1.8